### PR TITLE
Update changelog and bump version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,12 @@
 Changelog for package motoros2_interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add new ``enum`` value for incorrect cycle mode to ``MotionReadyEnum`` (`#10 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/10>`_)
+* Add definitions for ``GetActiveAlarmInfo`` service (`#9 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/9>`_)
+* Contributors: gavanderhoorn, John Rose
+
 0.1.0 (2023-08-29)
 ------------------
 * Initial release

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,8 @@
 Changelog for package motoros2_interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.1.1 (2024-03-15)
+------------------
 * Add new ``enum`` value for incorrect cycle mode to ``MotionReadyEnum`` (`#10 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/10>`_)
 * Add definitions for ``GetActiveAlarmInfo`` service (`#9 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/9>`_)
 * Contributors: gavanderhoorn, John Rose

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,14 @@
+..
+   SPDX-FileCopyrightText: 2023-2024, Yaskawa America, Inc.
+   SPDX-FileCopyrightText: 2023-2024, Delft University of Technology
+   
+   SPDX-License-Identifier: CC-BY-SA-4.0
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package motoros2_interfaces
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.1.0 (2023-08-29)
+------------------
+* Initial release
+* Contributors: gavanderhoorn, Ted Miller

--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>motoros2_interfaces</name>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <description>Messages, services and actions for use with MotoROS2</description>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <maintainer email="ted.miller@motoman.com">Ted Miller (Yaskawa Motoman)</maintainer>


### PR DESCRIPTION
As per title.

We need a new release to start building M+ `libmicroros` with #10 and #9.

Either only review, or use a *rebase merge* to merge.
