### PR TITLE
Update changelog and bump version (`0.1.2`)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,11 @@
 Changelog for package motoros2_interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Correct message for ``WRONG_MODE`` error (point queuing sub system) (`#15 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/15>`_)
+* Contributors: John Rose
+
 0.1.1 (2024-03-15)
 ------------------
 * Add new ``enum`` value for incorrect cycle mode to ``MotionReadyEnum`` (`#10 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/10>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,8 @@
 Changelog for package motoros2_interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.1.2 (2024-07-10)
+------------------
 * Correct message for ``WRONG_MODE`` error (point queuing sub system) (`#15 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/15>`_)
 * Contributors: John Rose
 

--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>motoros2_interfaces</name>
-  <version>0.1.1</version>
+  <version>0.1.2</version>
   <description>Messages, services and actions for use with MotoROS2</description>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <maintainer email="ted.miller@motoman.com">Ted Miller (Yaskawa Motoman)</maintainer>


### PR DESCRIPTION
Needed for MotoROS2 version `0.1.3` release.

Please only review, or use a *rebase merge* when merging.
