### PR TITLE
Add `ListInformJobs` service definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(msg_files
 
 set(srv_files
   srv/GetActiveAlarmInfo.srv
+  srv/ListInformJobs.srv
   srv/QueueTrajPoint.srv
   srv/ReadMRegister.srv
   srv/ReadSingleIO.srv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(msg_files
   msg/AlarmInfo.msg
   msg/AlarmCauseRemedy.msg
   msg/ErrorInfo.msg
+  msg/InformJobCrudResultCodes.msg
   msg/IoResultCodes.msg
   msg/MotionReadyEnum.msg
   msg/QueueResultEnum.msg

--- a/msg/InformJobCrudResultCodes.msg
+++ b/msg/InformJobCrudResultCodes.msg
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2024, Yaskawa America, Inc.
+# SPDX-FileCopyrightText: 2024, Delft University of Technology
+#
+# SPDX-License-Identifier: Apache-2.0
+
+uint32 RC_OK=1
+string STR_OK="Success"
+
+uint32 RC_ERR_REFRESHING_JOB_LIST=10
+string STR_ERR_REFRESHING_JOB_LIST="Error refreshing job list"
+
+uint32 RC_ERR_RETRIEVING_FILE_COUNT=11
+string STR_ERR_RETRIEVING_FILE_COUNT="Error retrieving file count"
+
+uint32 RC_ERR_TOO_MANY_JOBS=12
+string STR_ERR_TOO_MANY_JOBS="Too many jobs"
+
+uint32 RC_ERR_RETRIEVING_JOB_NAME_FROM_LIST=13
+string STR_ERR_RETRIEVING_JOB_NAME_FROM_LIST="Failed retrieving job name from list"
+
+uint32 RC_ERR_APPENDING_JOB_NAME_TO_SVC_RESPONSE=14
+string STR_ERR_APPENDING_JOB_NAME_TO_SVC_RESPONSE="Error adding job name to service response"

--- a/srv/ListInformJobs.srv
+++ b/srv/ListInformJobs.srv
@@ -9,6 +9,8 @@
 
 # Result of the service invocation. Values other than one (1) signal failure.
 #
+# Values defined in 'motoros2_interfaces/msg/InformJobCrudResultCodes'.
+#
 # NOTE: future versions of this service may use a different set of result
 # codes. Always make sure to compare against defined named constants instead
 # of integers directly.

--- a/srv/ListInformJobs.srv
+++ b/srv/ListInformJobs.srv
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2024, Yaskawa America, Inc.
+# SPDX-FileCopyrightText: 2024, Delft University of Technology
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# empty request
+
+---
+
+# Result of the service invocation. Values other than one (1) signal failure.
+#
+# NOTE: future versions of this service may use a different set of result
+# codes. Always make sure to compare against defined named constants instead
+# of integers directly.
+uint32 result_code
+
+# string representation of the value in 'result_code', for humans
+string message
+
+# The list of jobs present on the controller.
+#
+# NOTE:
+# - these are job names, not filenames, and thus will not include the file
+#   extension (JBI)
+# - character encodings other than ASCII are only partially supported
+string[] names


### PR DESCRIPTION
Part of INFORM Job CRUD and needed for Yaskawa-Global/motoros2#279.

This is a bit of a 'discussion' PR as I'm not completely sure about the design yet.
