### PR TITLE
Service and message definitions for reading and writing variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(msg_files
   msg/ErrorInfo.msg
   msg/InformJobCrudResultCodes.msg
   msg/IoResultCodes.msg
+  msg/VarResultCodes.msg
   msg/MotionReadyEnum.msg
   msg/QueueResultEnum.msg
   msg/SelectionResultCodes.msg
@@ -29,6 +30,12 @@ set(srv_files
   srv/ReadMRegister.srv
   srv/ReadSingleIO.srv
   srv/ReadGroupIO.srv
+  srv/ReadVarByte.srv
+  srv/ReadVarDouble.srv
+  srv/ReadVarInteger.srv
+  srv/ReadVarPosition.srv
+  srv/ReadVarReal.srv
+  srv/ReadVarString.srv
   srv/ResetError.srv
   srv/SelectMotionTool.srv
   srv/StartTrajMode.srv
@@ -36,6 +43,12 @@ set(srv_files
   srv/WriteMRegister.srv
   srv/WriteSingleIO.srv
   srv/WriteGroupIO.srv
+  srv/WriteVarByte.srv
+  srv/WriteVarDouble.srv
+  srv/WriteVarInteger.srv
+  srv/WriteVarPosition.srv
+  srv/WriteVarReal.srv
+  srv/WriteVarString.srv
 )
 
 if(BUILD_TESTING)

--- a/msg/VarResultCodes.msg
+++ b/msg/VarResultCodes.msg
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2022-2023, Yaskawa America, Inc.
+# SPDX-FileCopyrightText: 2022-2023, Delft University of Technology
+#
+# SPDX-License-Identifier: Apache-2.0
+
+uint32 OK=0
+string OK_STR="Success"
+
+# The ioAddress cannot be read on this controller
+uint32 READ_ADDRESS_INVALID=1001
+string READ_ADDRESS_INVALID_STR="Address cannot be read from (out of readable range)"
+
+# The ioAddress cannot be written to on this controller
+uint32 WRITE_ADDRESS_INVALID=1002
+string WRITE_ADDRESS_INVALID_STR="Address cannot be written to (out of writable range)"
+
+# The value supplied is not a valid value for the addressed IO element
+uint32 WRITE_VALUE_INVALID=1003
+string WRITE_VALUE_INVALID_STR="Illegal value for the type of IO element addressed"
+
+# mpReadIO return -1
+uint32 READ_API_ERROR=1004
+string READ_API_ERROR_STR="The MotoPlus function mpReadIO returned -1. No further information is available"
+
+# mpWriteIO returned -1
+uint32 WRITE_API_ERROR=1005
+string WRITE_API_ERROR_STR="The MotoPlus function mpWriteIO returned -1. No further information is available"
+
+# Unknown fallback failure
+string UNKNOWN_API_ERROR_STR="Unknown error accessing I/O. No further information is available"

--- a/msg/VarResultCodes.msg
+++ b/msg/VarResultCodes.msg
@@ -3,28 +3,28 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-uint32 OK=0
-string OK_STR="Success"
+uint32 OK = 0
+string OK_STR = "Success"
 
-# The ioAddress cannot be read on this controller
-uint32 READ_ADDRESS_INVALID=1001
-string READ_ADDRESS_INVALID_STR="Address cannot be read from (out of readable range)"
+# The variable number cannot be read on this controller
+uint32 READ_VAR_NUMBER_INVALID = 1001
+string READ_VAR_NUMBER_INVALID_STR = "Variable number cannot be read from (out of readable range)"
 
-# The ioAddress cannot be written to on this controller
-uint32 WRITE_ADDRESS_INVALID=1002
-string WRITE_ADDRESS_INVALID_STR="Address cannot be written to (out of writable range)"
+# The variable number cannot be written to on this controller
+uint32 WRITE_VAR_NUMBER_INVALID = 1002
+string WRITE_VAR_NUMBER_INVALID_STR = "Variable number cannot be written to (out of writable range)"
 
 # The value supplied is not a valid value for the addressed IO element
-uint32 WRITE_VALUE_INVALID=1003
-string WRITE_VALUE_INVALID_STR="Illegal value for the type of IO element addressed"
+uint32 WRITE_VALUE_INVALID = 1003
+string WRITE_VALUE_INVALID_STR = "Illegal value for the type of IO element addressed"
 
-# mpReadIO return -1
-uint32 READ_API_ERROR=1004
-string READ_API_ERROR_STR="The MotoPlus function mpReadIO returned -1. No further information is available"
+# mpGetUserVars returned -1
+uint32 READ_API_ERROR = 1004
+string READ_API_ERROR_STR = "The MotoPlus function mpGetUserVars returned -1, indicating an accessing error. No further information is available"
 
-# mpWriteIO returned -1
-uint32 WRITE_API_ERROR=1005
-string WRITE_API_ERROR_STR="The MotoPlus function mpWriteIO returned -1. No further information is available"
+# mpPutUserVars returned -1
+uint32 WRITE_API_ERROR = 1005
+string WRITE_API_ERROR_STR = "The MotoPlus function mpPutUserVars returned -1, indicating an accessing error. No further information is available"
 
 # Unknown fallback failure
-string UNKNOWN_API_ERROR_STR="Unknown error accessing I/O. No further information is available"
+string UNKNOWN_API_ERROR_STR = "Unknown error accessing I/O. No further information is available"

--- a/srv/ReadVarByte.srv
+++ b/srv/ReadVarByte.srv
@@ -5,7 +5,7 @@
 
 uint32 var_number
 ---
-# legal values defined in IoResultCodes.msg
+# legal values defined in VarResultCodes.msg
 uint32 result_code
 string message
 bool success

--- a/srv/ReadVarByte.srv
+++ b/srv/ReadVarByte.srv
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2023, Yaskawa America, Inc.
+# SPDX-FileCopyrightText: 2023, Delft University of Technology
+#
+# SPDX-License-Identifier: Apache-2.0
+
+uint32 var_number
+---
+# legal values defined in IoResultCodes.msg
+uint32 result_code
+string message
+bool success
+uint8 value

--- a/srv/ReadVarDouble.srv
+++ b/srv/ReadVarDouble.srv
@@ -5,7 +5,7 @@
 
 uint32 var_number
 ---
-# legal values defined in IoResultCodes.msg
+# legal values defined in VarResultCodes.msg
 uint32 result_code
 string message
 bool success

--- a/srv/ReadVarDouble.srv
+++ b/srv/ReadVarDouble.srv
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2023, Yaskawa America, Inc.
+# SPDX-FileCopyrightText: 2023, Delft University of Technology
+#
+# SPDX-License-Identifier: Apache-2.0
+
+uint32 var_number
+---
+# legal values defined in IoResultCodes.msg
+uint32 result_code
+string message
+bool success
+uint32 value

--- a/srv/ReadVarInteger.srv
+++ b/srv/ReadVarInteger.srv
@@ -5,7 +5,7 @@
 
 uint32 var_number
 ---
-# legal values defined in IoResultCodes.msg
+# legal values defined in VarResultCodes.msg
 uint32 result_code
 string message
 bool success

--- a/srv/ReadVarInteger.srv
+++ b/srv/ReadVarInteger.srv
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2023, Yaskawa America, Inc.
+# SPDX-FileCopyrightText: 2023, Delft University of Technology
+#
+# SPDX-License-Identifier: Apache-2.0
+
+uint32 var_number
+---
+# legal values defined in IoResultCodes.msg
+uint32 result_code
+string message
+bool success
+uint16 value

--- a/srv/ReadVarPosition.srv
+++ b/srv/ReadVarPosition.srv
@@ -5,7 +5,7 @@
 
 uint32 var_number
 ---
-# legal values defined in IoResultCodes.msg
+# legal values defined in VarResultCodes.msg
 uint32 result_code
 string message
 bool success

--- a/srv/ReadVarPosition.srv
+++ b/srv/ReadVarPosition.srv
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2023, Yaskawa America, Inc.
+# SPDX-FileCopyrightText: 2023, Delft University of Technology
+#
+# SPDX-License-Identifier: Apache-2.0
+
+uint32 var_number
+---
+# legal values defined in IoResultCodes.msg
+uint32 result_code
+string message
+bool success
+
+# always returned in 'base' frame
+# NOTE: the ROS-Industrial 'base' frame, not Yaskawa Base frame
+geometry_msgs/PoseStamped value

--- a/srv/ReadVarReal.srv
+++ b/srv/ReadVarReal.srv
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2023, Yaskawa America, Inc.
+# SPDX-FileCopyrightText: 2023, Delft University of Technology
+#
+# SPDX-License-Identifier: Apache-2.0
+
+uint32 var_number
+---
+# legal values defined in IoResultCodes.msg
+uint32 result_code
+string message
+bool success
+float32 value

--- a/srv/ReadVarReal.srv
+++ b/srv/ReadVarReal.srv
@@ -5,7 +5,7 @@
 
 uint32 var_number
 ---
-# legal values defined in IoResultCodes.msg
+# legal values defined in VarResultCodes.msg
 uint32 result_code
 string message
 bool success

--- a/srv/ReadVarString.srv
+++ b/srv/ReadVarString.srv
@@ -5,7 +5,7 @@
 
 uint32 var_number
 ---
-# legal values defined in IoResultCodes.msg
+# legal values defined in VarResultCodes.msg
 uint32 result_code
 string message
 bool success

--- a/srv/ReadVarString.srv
+++ b/srv/ReadVarString.srv
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2023, Yaskawa America, Inc.
+# SPDX-FileCopyrightText: 2023, Delft University of Technology
+#
+# SPDX-License-Identifier: Apache-2.0
+
+uint32 var_number
+---
+# legal values defined in IoResultCodes.msg
+uint32 result_code
+string message
+bool success
+string value

--- a/srv/WriteVarByte.srv
+++ b/srv/WriteVarByte.srv
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2023, Yaskawa America, Inc.
+# SPDX-FileCopyrightText: 2023, Delft University of Technology
+#
+# SPDX-License-Identifier: Apache-2.0
+
+uint32 var_number
+uint8 value
+---
+# legal values defined in VarResultCodes.msg
+uint32 result_code
+string message
+bool success

--- a/srv/WriteVarDouble.srv
+++ b/srv/WriteVarDouble.srv
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2023, Yaskawa America, Inc.
+# SPDX-FileCopyrightText: 2023, Delft University of Technology
+#
+# SPDX-License-Identifier: Apache-2.0
+
+uint32 var_number
+uint32 value
+---
+# legal values defined in VarResultCodes.msg
+uint32 result_code
+string message
+bool success

--- a/srv/WriteVarInteger.srv
+++ b/srv/WriteVarInteger.srv
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2023, Yaskawa America, Inc.
+# SPDX-FileCopyrightText: 2023, Delft University of Technology
+#
+# SPDX-License-Identifier: Apache-2.0
+
+uint32 var_number
+uint16 value
+---
+# legal values defined in VarResultCodes.msg
+uint32 result_code
+string message
+bool success

--- a/srv/WriteVarPosition.srv
+++ b/srv/WriteVarPosition.srv
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2023, Yaskawa America, Inc.
+# SPDX-FileCopyrightText: 2023, Delft University of Technology
+#
+# SPDX-License-Identifier: Apache-2.0
+
+uint32 var_number
+
+# only poses defined in 'base' frame will be accepted
+#
+# NOTE: the ROS-Industrial 'base' frame, not Yaskawa Base frame
+#
+# NOTE 2: it's the responsibility of the client to transform poses into this
+#         frame. The server will reject poses not already in 'base' frame.
+geometry_msgs/PoseStamped value
+---
+# legal values defined in VarResultCodes.msg
+uint32 result_code
+string message
+bool success

--- a/srv/WriteVarReal.srv
+++ b/srv/WriteVarReal.srv
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2023, Yaskawa America, Inc.
+# SPDX-FileCopyrightText: 2023, Delft University of Technology
+#
+# SPDX-License-Identifier: Apache-2.0
+
+uint32 var_number
+float32 value
+---
+# legal values defined in VarResultCodes.msg
+uint32 result_code
+string message
+bool success

--- a/srv/WriteVarString.srv
+++ b/srv/WriteVarString.srv
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2023, Yaskawa America, Inc.
+# SPDX-FileCopyrightText: 2023, Delft University of Technology
+#
+# SPDX-License-Identifier: Apache-2.0
+
+uint32 var_number
+string value
+---
+# legal values defined in VarResultCodes.msg
+uint32 result_code
+string message
+bool success


### PR DESCRIPTION
Added service definitions for reading and writing each variable type. A message definition for the error codes has also been added.

Each service definition has "var_number" as the variable name in the request section, as this wording fits better with the MotoPlus function definition used, than using the name "address".

For reading and writing position variables, the service has been kept as proposed. The positions are in the ROS-Industrial base frame. A corresponding motoros2 function will convert this ROS-Industrial base frame position to a Yaskawa base frame position and vice versa, since the robot controller it self cannot deal with the ROS-Industrial base frame directly. If needed, the option to define positions in the tool or user frame can be added in a later version.