### PR TITLE
0.1.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,12 @@
 Changelog for package motoros2_interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add ``MotionNotReady`` codes for major alarms, power saving mode, and servo timeout (`#17 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/17>`_ and `#23 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/23>`_)
+* Add definition for ``ListInformJobs`` service (`#21 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/21>`_)
+* Contributors: gavanderhoorn, Jimmy McElwain
+
 0.1.2 (2024-07-10)
 ------------------
 * Correct message for ``WRONG_MODE`` error (point queuing sub system) (`#15 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/15>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,8 @@
 Changelog for package motoros2_interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.1.3 (2024-09-16)
+------------------
 * Add ``MotionNotReady`` codes for major alarms, power saving mode, and servo timeout (`#17 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/17>`_ and `#23 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/23>`_)
 * Add definition for ``ListInformJobs`` service (`#21 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/21>`_)
 * Contributors: gavanderhoorn, Jimmy McElwain

--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>motoros2_interfaces</name>
-  <version>0.1.2</version>
+  <version>0.1.3</version>
   <description>Messages, services and actions for use with MotoROS2</description>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <maintainer email="ted.miller@motoman.com">Ted Miller (Yaskawa Motoman)</maintainer>


### PR DESCRIPTION
* Add definition for ``ListInformJobs`` service (`#21 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/21>`_)
* Add ``MotionNotReady`` codes for major alarms, power saving mode, and servo timeout (`#23 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/23>`_ and `#17 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/17>`_)
* Contributors: gavanderhoorn, jimmy-mcelwain