### PR TITLE
Have QueueResultEnum.msg value type match InitTrajEnum.msg value

### DIFF
--- a/msg/QueueResultEnum.msg
+++ b/msg/QueueResultEnum.msg
@@ -5,22 +5,22 @@
 
 # The result code for an attempted invocation of the queue_traj_point service
 
-uint8 SUCCESS=1
+uint16 SUCCESS=1
 string SUCCESS_STR=""
 
-uint8 WRONG_MODE=2
+uint16 WRONG_MODE=2
 string WRONG_MODE_STR="Must call start_point_queue_mode service"
 
-uint8 INIT_FAILURE=3
+uint16 INIT_FAILURE=3
 string INIT_FAILURE_STR="Failed to initialize the streaming trajectory"
 
-uint8 BUSY=4
+uint16 BUSY=4
 string BUSY_STR="Busy processing the previous trajectory point. Please resend the next point shortly"
 
-uint8 INVALID_JOINT_LIST=5
+uint16 INVALID_JOINT_LIST=5
 string INVALID_JOINT_LIST_STR="Point must contain data for all joints"
 
-uint8 UNABLE_TO_PROCESS_POINT=6
+uint16 UNABLE_TO_PROCESS_POINT=6
 string UNABLE_TO_PROCESS_POINT_STR="Error while processing the trajectory point. Check debug log for more details"
 
-uint8 value
+uint16 value


### PR DESCRIPTION
As I mentioned at https://github.com/Yaskawa-Global/motoros2/pull/341#issuecomment-2528637158, if we are forwarding the response from `InitTrajEnum.msg` to `queue_traj_point`, the `QueueResultEnum.msg` `value` is going to have to increase to match the size of the `InitTrajEnum.msg` `value`. 

The choice between changing the `QueueResultEnum.msg` `value` to be `uint16` and the `InitTrajEnum.msg` `value` to be `uint8` seems sort of arbitrary, so I went with the wider value just because it is a bit more flexible and it should be okay for setting the `error_code` [here](https://github.com/Yaskawa-Global/motoros2/blob/311713e9f5dca3fc337e60b4460d3a331d395d7d/src/ActionServer_FJT.c#L272). If anybody would rather go with `uint8` for both, I can change it. 

This may break compatibility. 