### PR TITLE
Update changelog and bump version 0.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,11 @@
 Changelog for package motoros2_interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Change ``QueueResultEnum`` ``value`` type to match ``Init_Trajectory_Status`` enum ``value`` type. ``uint8 -> uint16`` (`#30 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/30>`_)
+* Contributors: Jimmy McElwain
+
 0.1.4 (2024-11-27)
 ------------------
 * Move ``Init_Trajectory_Status`` enum from MotoROS2 repo to ``.msg`` (`#26 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/26>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,8 @@
 Changelog for package motoros2_interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.2.0 (2025-02-04)
+------------------
 * Change ``QueueResultEnum`` ``value`` type to match ``Init_Trajectory_Status`` enum ``value`` type. ``uint8 -> uint16`` (`#30 <https://github.com/Yaskawa-Global/motoros2_interfaces/pull/30>`_)
 * Contributors: Jimmy McElwain
 

--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>motoros2_interfaces</name>
-  <version>0.1.3</version>
+  <version>0.2.0</version>
   <description>Messages, services and actions for use with MotoROS2</description>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <maintainer email="ted.miller@motoman.com">Ted Miller (Yaskawa Motoman)</maintainer>


### PR DESCRIPTION
As discussed in https://github.com/Yaskawa-Global/motoros2/pull/364, we want version `0.2.0` of MotoROS2 to have this update since to potentially decrease the number of breaking updates in the future. 